### PR TITLE
Avoid unnecessary square calculation and (maybe?) skip unneeded code

### DIFF
--- a/src/games/september/shared.ts
+++ b/src/games/september/shared.ts
@@ -20,8 +20,8 @@ export function calculateTurn(positive: Positive, negatives: Negative[]) {
         const dX = positive.x.neg().add(negative.x);
         const dY = positive.y.neg().add(negative.y);
         const distance = dX.pow(2).plus(dY.pow(2));
-        if (distance.isZero()) continue;
         if (distance.lt(MAGNET_RADIUS_SQ)) return 'hit magnet';
+        // if (distance.isZero()) continue; // never actually true
         totalTurn = totalTurn.plus(Decimal.atan2(dY, dX).sub(positive.angle!).sin().div(distance).mul(GRAVITY));
     }
     return totalTurn;

--- a/src/games/september/shared.ts
+++ b/src/games/september/shared.ts
@@ -3,6 +3,7 @@ import {Negative, Positive} from './index.ts';
 
 export const MAGNET_PICKUP_RADIUS = 20;
 export const MAGNET_RADIUS = 10;
+export const MAGNET_RADIUS_SQ = 100;
 export const MAGNET_SPEED = 4;
 export const MAX_SIMULATION_STEPS = 10000;
 
@@ -16,11 +17,11 @@ const GRAVITY = 100;
 export function calculateTurn(positive: Positive, negatives: Negative[]) {
     let totalTurn = new Decimal(0);
     for (const negative of negatives) {
-        const dX = positive.x.neg().add(negative.x);
-        const dY = positive.y.neg().add(negative.y);
+        const dX = negative.x.minus(positive.x);
+        const dY = negative.y.minus(positive.y);
         const distance = dX.pow(2).plus(dY.pow(2));
-        if (distance.lt(MAGNET_RADIUS ** 2)) return 'hit magnet';
         if (distance.isZero()) continue;
+        if (distance.lt(MAGNET_RADIUS_SQ)) return 'hit magnet';
         totalTurn = totalTurn.plus(Decimal.atan2(dY, dX).sub(positive.angle!).sin().div(distance).mul(GRAVITY));
     }
     return totalTurn;

--- a/src/games/september/shared.ts
+++ b/src/games/september/shared.ts
@@ -17,8 +17,8 @@ const GRAVITY = 100;
 export function calculateTurn(positive: Positive, negatives: Negative[]) {
     let totalTurn = new Decimal(0);
     for (const negative of negatives) {
-        const dX = negative.x.minus(positive.x);
-        const dY = negative.y.minus(positive.y);
+        const dX = positive.x.neg().add(negative.x);
+        const dY = positive.y.neg().add(negative.y);
         const distance = dX.pow(2).plus(dY.pow(2));
         if (distance.isZero()) continue;
         if (distance.lt(MAGNET_RADIUS_SQ)) return 'hit magnet';


### PR DESCRIPTION
I tried to optimize the physics calculation to maybe speed up preview calculation by:

- Mainly using static 100 instead of squaring 10 every time
- skipping check for distance if is already zero
- use 'negative - positive' instead of '-positive + negative'

Hopefully this actually speeds up things a little. Can't imagine it'll do much, but also not nothing. :D